### PR TITLE
recast intends visitors to be shared

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,93 +5,7 @@ var through = require('through');
 var b = recast.types.builders;
 var n = recast.types.namedTypes;
 
-function Visitor() {
-  types.PathVisitor.call(this);
-}
-
-Visitor.prototype = Object.create(types.PathVisitor.prototype);
-Visitor.prototype.constructor = Visitor;
-
-Visitor.prototype.visitProperty = function(path) {
-  var expr = path.node;
-
-  if (expr.method && n.FunctionExpression.check(expr.value)) {
-    expr.method = false;
-
-    if (refersTo(expr.value, expr.key)) {
-      var fnArg = astUtil.uniqueIdentifier(path.scope, expr.key.name);
-      var wrapperFn = astUtil.uniqueIdentifier(path.scope, 'wrapper');
-
-      expr.value = b.callExpression(
-        b.functionExpression(
-          null,
-          [fnArg],
-          b.blockStatement([
-            b.variableDeclaration(
-              'var',
-              [
-                b.variableDeclarator(
-                  wrapperFn,
-                  b.functionExpression(
-                    expr.key,
-                    [],
-                    b.blockStatement([
-                      b.returnStatement(
-                        b.callExpression(
-                          b.memberExpression(
-                            fnArg,
-                            b.identifier('apply'),
-                            false
-                          ),
-                          [
-                            b.thisExpression(),
-                            b.identifier('arguments')
-                          ]
-                        )
-                      )
-                    ])
-                  )
-                )
-              ]
-            ),
-            b.expressionStatement(
-              b.assignmentExpression(
-                '=',
-                b.memberExpression(
-                  wrapperFn,
-                  b.identifier('toString'),
-                  false
-                ),
-                b.functionExpression(
-                  null,
-                  [],
-                  b.blockStatement([
-                    b.returnStatement(
-                      b.callExpression(
-                        b.memberExpression(
-                          fnArg,
-                          b.identifier('toString'),
-                          false
-                        ),
-                        []
-                      )
-                    )
-                  ])
-                )
-              )
-            ),
-            b.returnStatement(wrapperFn)
-          ])
-        ),
-        [expr.value]
-      );
-    } else {
-      expr.value.id = expr.key;
-    }
-  }
-
-  return expr;
-};
+var Visitor = require('./visitor');
 
 function refersTo(fn, identifier) {
   var result = false;
@@ -110,7 +24,7 @@ function refersTo(fn, identifier) {
 }
 
 function transform(ast) {
-  recast.visit(ast, new Visitor());
+  recast.visit(ast, Visitor.visitor);
   return ast;
 }
 

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,0 +1,113 @@
+var recast = require('recast');
+var types = recast.types;
+var astUtil = require('ast-util');
+var through = require('through');
+var b = recast.types.builders;
+var n = recast.types.namedTypes;
+
+function Visitor() {
+  types.PathVisitor.call(this);
+}
+
+Visitor.prototype = Object.create(types.PathVisitor.prototype);
+Visitor.prototype.constructor = Visitor;
+
+Visitor.prototype.visitProperty = function(path) {
+  var expr = path.node;
+
+  if (expr.method && n.FunctionExpression.check(expr.value)) {
+    expr.method = false;
+
+    if (refersTo(expr.value, expr.key)) {
+      var fnArg = astUtil.uniqueIdentifier(path.scope, expr.key.name);
+      var wrapperFn = astUtil.uniqueIdentifier(path.scope, 'wrapper');
+
+      expr.value = b.callExpression(
+        b.functionExpression(
+          null,
+          [fnArg],
+          b.blockStatement([
+            b.variableDeclaration(
+              'var',
+              [
+                b.variableDeclarator(
+                  wrapperFn,
+                  b.functionExpression(
+                    expr.key,
+                    [],
+                    b.blockStatement([
+                      b.returnStatement(
+                        b.callExpression(
+                          b.memberExpression(
+                            fnArg,
+                            b.identifier('apply'),
+                            false
+                          ),
+                          [
+                            b.thisExpression(),
+                            b.identifier('arguments')
+                          ]
+                        )
+                      )
+                    ])
+                  )
+                )
+              ]
+            ),
+            b.expressionStatement(
+              b.assignmentExpression(
+                '=',
+                b.memberExpression(
+                  wrapperFn,
+                  b.identifier('toString'),
+                  false
+                ),
+                b.functionExpression(
+                  null,
+                  [],
+                  b.blockStatement([
+                    b.returnStatement(
+                      b.callExpression(
+                        b.memberExpression(
+                          fnArg,
+                          b.identifier('toString'),
+                          false
+                        ),
+                        []
+                      )
+                    )
+                  ])
+                )
+              )
+            ),
+            b.returnStatement(wrapperFn)
+          ])
+        ),
+        [expr.value]
+      );
+    } else {
+      expr.value.id = expr.key;
+    }
+  }
+
+  return expr;
+};
+
+Visitor.visitor = new Visitor();
+
+function refersTo(fn, identifier) {
+  var result = false;
+
+  recast.visit(fn, types.PathVisitor.fromMethodsObject({
+    visitIdentifier: function(path) {
+      if (!result && astUtil.isReference(path, identifier.name)) {
+        result = true;
+      }
+
+      return false;
+    }
+  }));
+
+  return result;
+}
+module.exports = Visitor;


### PR DESCRIPTION
- extract visitor to own file
- use shared visitor

before:

``` js
node benchmarks/esnext-transform es6-object-concise test-input/*                                                                                                                                 !10092
running...
  - test-input/controller-es5.js x 402 ops/sec ±5.04% (78 runs sampled)
  - test-input/controller.js x 362 ops/sec ±7.22% (72 runs sampled)
  - test-input/empty.js x 8,261 ops/sec ±9.88% (69 runs sampled)
  - test-input/jquery-1.11.1.js x 2.93 ops/sec ±5.74% (11 runs sampled)
  - test-input/simple-export-default-class.js x 3,289 ops/sec ±9.27% (74 runs sampled)
Fastest is test-input/empty.js
```

after:

``` js
node benchmarks/esnext-transform es6-object-concise test-input/*                                                                                                                                 !10104
running...
  - test-input/controller-es5.js x 424 ops/sec ±5.23% (75 runs sampled)
  - test-input/controller.js x 432 ops/sec ±3.85% (74 runs sampled)
  - test-input/empty.js x 85,091 ops/sec ±3.84% (77 runs sampled)
  - test-input/jquery-1.11.1.js x 3.10 ops/sec ±6.76% (12 runs sampled)
  - test-input/simple-export-default-class.js x 6,613 ops/sec ±3.72% (79 runs sampled)
```
